### PR TITLE
Fix: Check if Sign is a directional sign before casting

### DIFF
--- a/main/src/xyz/nuyube/minecraft/lcup/ChestOpenEventHandler.java
+++ b/main/src/xyz/nuyube/minecraft/lcup/ChestOpenEventHandler.java
@@ -45,10 +45,12 @@ class ChestOpenEventHandler implements Listener {
                 Player p = event.getPlayer();
                 // Get info about the sign
                 Sign S = (Sign) clickedBlock.getState();
-                // Get the block attached to the sign
-                Directional a = (Directional) S.getBlockData();
-                Block Attached = clickedBlock.getRelative(a.getFacing().getOppositeFace());
-                handleBlockState(Attached, p);
+                if (S instanceof Directional) {
+                    // Get the block attached to the sign
+                    Directional a = (Directional) S.getBlockData();
+                    Block Attached = clickedBlock.getRelative(a.getFacing().getOppositeFace());
+                    handleBlockState(Attached, p);
+                }
             }
         }
     }


### PR DESCRIPTION
Right-clicking standing signs triggers a cast exception. This fixes that. Also, you should update the maven URL of jeff-media-gbr to https://hub.jeff-media.com/nexus/repository/jeff-media-public/.